### PR TITLE
SN5-55 SN5-56- Accept/Reject Application, Musician Application List

### DIFF
--- a/backend/pages/serializers/application_serializers.py
+++ b/backend/pages/serializers/application_serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from pages.models import JobApplication, User, Experience
+from pages.models import JobApplication, User, Experience, JobListing
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -11,15 +11,21 @@ class ExperienceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Experience
         fields = ['job_title', 'company_name', 'start_date', 'end_date', 'description']
+        
+class JobListingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = JobListing
+        fields = ["id", "event_title"]
 
         
 class JobApplicationSerializer(serializers.ModelSerializer):
     applicant = UserSerializer()
+    listing = JobListingSerializer()
     experiences = ExperienceSerializer(many=True, read_only=True)
     
     class Meta:
         model = JobApplication
         fields = [
-            'id', 'applicant', 'first_name', 'last_name', 'phone', 'alt_email',
+            'id', 'listing', 'applicant', 'first_name', 'last_name', 'phone', 'alt_email',
             'file_keys', 'status', 'experiences'
         ]

--- a/backend/pages/views/application_views.py
+++ b/backend/pages/views/application_views.py
@@ -240,3 +240,19 @@ class SendRejectionEmail(APIView):
 
         except JobApplication.DoesNotExist:
             return Response({"error": "Application not found."}, status=status.HTTP_404_NOT_FOUND)
+        
+class UserApplicationsView(APIView, PageNumberPagination):
+    permission_classes = [IsAuthenticated]
+    page_size = 3
+
+    def get(self, request, *args, **kwargs):
+        user = request.user
+        applications = JobApplication.objects.filter(applicant=user)
+
+        paginated_applications = self.paginate_queryset(applications, request)
+        
+        # Serialize data
+        serializer = JobApplicationSerializer(paginated_applications, many=True)
+        print(serializer.data)
+        
+        return self.get_paginated_response(serializer.data)

--- a/backend/pages/views/application_views.py
+++ b/backend/pages/views/application_views.py
@@ -236,7 +236,7 @@ class SendRejectionEmail(APIView):
             )
             print(email)
 
-            return Response({"message": "Acceptance email sent successfully."}, status=status.HTTP_200_OK)
+            return Response({"message": "Rejection email sent successfully."}, status=status.HTTP_200_OK)
 
         except JobApplication.DoesNotExist:
             return Response({"error": "Application not found."}, status=status.HTTP_404_NOT_FOUND)

--- a/backend/test/views/application/ApplicationViewTest.py
+++ b/backend/test/views/application/ApplicationViewTest.py
@@ -1,5 +1,7 @@
 import pytest
 import uuid
+from django.core import mail
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
 from pages.models import User, JobListing, Instrument, Genre, Business, JobApplication, Experience
@@ -10,6 +12,9 @@ PATCH_APPLICATION_URL = "/api/patch-application/{}/"
 GET_APPLICATION_URL = "/api/job-application/{}/"
 AUTOFILL_RESUME_URL = "/api/parse-resume/"
 APPLICATION_EXPERIENCE_URL = "/api/job-application/{}/submit-experiences/"
+SEND_ACCEPTANCE_EMAIL_URL = "/api/send-acceptance-email/"
+SEND_REJECTION_EMAIL_URL = "/api/send-reject-email/"
+USER_APPLICATIONS_URL = "/api/applications/user/"
 
 
 @pytest.fixture
@@ -177,3 +182,142 @@ def test_autofill_resume_missing_key(auth_client):
     response = auth_client.post(AUTOFILL_RESUME_URL, {}, format="json")
     assert response.status_code == 400
     assert response.data["error"] == "Missing s3_key"
+    
+@pytest.mark.django_db
+def test_send_acceptance_email_success(auth_client, job_listing, create_user):
+    """Test sending an acceptance email for a valid application."""
+    app = JobApplication.objects.create(
+        applicant=create_user,
+        listing=job_listing,
+        first_name="Jane",
+        last_name="Doe",
+        alt_email="jane.alt@example.com",
+        phone="1234567890"
+    )
+
+    data = {
+        "application_id": str(app.id),
+        "app_email": "jane.alt@example.com"
+    }
+
+    response = auth_client.post(SEND_ACCEPTANCE_EMAIL_URL, data, format="json")
+
+    assert response.status_code == 200
+    assert response.data["message"] == "Acceptance email sent successfully."
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == "SavvyNote - Application Accepted"
+    assert "Congratulations" in mail.outbox[0].body or mail.outbox[0].alternatives[0][0]
+
+@pytest.mark.django_db
+def test_send_acceptance_email_missing_id(auth_client):
+    """Test sending email with missing application_id."""
+    data = {
+        "app_email": "someone@example.com"
+    }
+
+    response = auth_client.post(SEND_ACCEPTANCE_EMAIL_URL, data, format="json")
+
+    assert response.status_code == 400
+    assert response.data["error"] == "Application ID is required."
+
+@pytest.mark.django_db
+def test_send_acceptance_email_app_not_found(auth_client):
+    """Test sending email with a non-existent application ID."""
+    random_uuid = uuid.uuid4()
+
+    data = {
+        "application_id": str(random_uuid),
+        "app_email": "someone@example.com"
+    }
+
+    response = auth_client.post(SEND_ACCEPTANCE_EMAIL_URL, data, format="json")
+
+    assert response.status_code == 404
+    assert response.data["error"] == "Application not found."
+    
+@pytest.mark.django_db
+def test_send_rejection_email_success(auth_client, job_listing, create_user):
+    """Test sending an acceptance email for a valid application."""
+    app = JobApplication.objects.create(
+        applicant=create_user,
+        listing=job_listing,
+        first_name="Jane",
+        last_name="Doe",
+        alt_email="jane.alt@example.com",
+        phone="1234567890"
+    )
+
+    data = {
+        "application_id": str(app.id),
+        "app_email": "jane.alt@example.com"
+    }
+
+    response = auth_client.post(SEND_REJECTION_EMAIL_URL, data, format="json")
+
+    assert response.status_code == 200
+    assert response.data["message"] == "Rejection email sent successfully."
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == "SavvyNote - Application Update"
+    assert "Dear" in mail.outbox[0].body or mail.outbox[0].alternatives[0][0]
+
+@pytest.mark.django_db
+def test_send_rejection_email_missing_id(auth_client):
+    """Test sending email with missing application_id."""
+    data = {
+        "app_email": "someone@example.com"
+    }
+
+    response = auth_client.post(SEND_REJECTION_EMAIL_URL, data, format="json")
+
+    assert response.status_code == 400
+    assert response.data["error"] == "Application ID is required."
+
+@pytest.mark.django_db
+def test_send_rejection_email_app_not_found(auth_client):
+    """Test sending email with a non-existent application ID."""
+    random_uuid = uuid.uuid4()
+
+    data = {
+        "application_id": str(random_uuid),
+        "app_email": "someone@example.com"
+    }
+
+    response = auth_client.post(SEND_REJECTION_EMAIL_URL, data, format="json")
+
+    assert response.status_code == 404
+    assert response.data["error"] == "Application not found."
+    
+@pytest.mark.django_db
+def test_user_applications_view_returns_correct_applications(auth_client, job_listing, create_user):
+    """Test that the user applications view returns only the applications for the authenticated user."""
+    # Create applications for the test user
+    JobApplication.objects.create(
+        applicant=create_user,
+        listing=job_listing,
+        first_name="Jane",
+        last_name="Doe",
+        alt_email="alt@example.com",
+        phone="1234567890"
+    )
+    JobApplication.objects.create(
+        applicant=create_user,
+        listing=job_listing,
+        first_name="Janet",
+        last_name="Smith",
+        alt_email="janet@example.com",
+        phone="9876543210"
+    )
+
+    response = auth_client.get(USER_APPLICATIONS_URL)
+    print(response.data)
+    assert response.status_code == 200
+    assert response.data["count"] == 2
+    assert {app["first_name"] for app in response.data["results"]} == {"Jane", "Janet"}
+
+
+@pytest.mark.django_db
+def test_user_applications_view_empty(auth_client):
+    """Test that the user applications view returns an empty list if the user has no applications."""
+    response = auth_client.get(USER_APPLICATIONS_URL)
+    assert response.status_code == 200
+    assert response.data["count"] == 0

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -7,7 +7,7 @@ from pages.views.post_views import *
 from pages.views.blocked_views import BlockUserView, BlockedListView
 from pages.views.dropdown_views import get_instruments, get_genres
 from pages.views.listing_views import CreateJobListingView, GetJobListingsView, GetAllJobListingsView, GetJobListingView, GetUserFromBusinessView
-from pages.views.application_views import CreateApplicationView, ApplicationsForListingView, AutofillResumeView, GetApplication, SubmitExperiencesView, PatchApplication, SendAcceptanceEmail
+from pages.views.application_views import CreateApplicationView, ApplicationsForListingView, AutofillResumeView, GetApplication, SubmitExperiencesView, PatchApplication, SendAcceptanceEmail, SendRejectionEmail
 from django.http import JsonResponse
 
 # For debugging:
@@ -60,5 +60,6 @@ urlpatterns = [
         path('job-application/<uuid:app_id>/submit-experiences/', SubmitExperiencesView.as_view(), name='submit-experiences'),
         path('user-from-business/<uuid:business_id>/', GetUserFromBusinessView.as_view(), name="user-from-business"),
         path("send-acceptance-email/", SendAcceptanceEmail.as_view(), name="send_acceptance_email"),
+        path("send-reject-email/", SendRejectionEmail.as_view(), name="send_reject_email"),
     ])),
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -7,7 +7,7 @@ from pages.views.post_views import *
 from pages.views.blocked_views import BlockUserView, BlockedListView
 from pages.views.dropdown_views import get_instruments, get_genres
 from pages.views.listing_views import CreateJobListingView, GetJobListingsView, GetAllJobListingsView, GetJobListingView, GetUserFromBusinessView
-from pages.views.application_views import CreateApplicationView, ApplicationsForListingView, AutofillResumeView, GetApplication, SubmitExperiencesView, PatchApplication, SendAcceptanceEmail, SendRejectionEmail
+from pages.views.application_views import CreateApplicationView, ApplicationsForListingView, AutofillResumeView, GetApplication, SubmitExperiencesView, PatchApplication, SendAcceptanceEmail, SendRejectionEmail, UserApplicationsView
 from django.http import JsonResponse
 
 # For debugging:
@@ -61,5 +61,6 @@ urlpatterns = [
         path('user-from-business/<uuid:business_id>/', GetUserFromBusinessView.as_view(), name="user-from-business"),
         path("send-acceptance-email/", SendAcceptanceEmail.as_view(), name="send_acceptance_email"),
         path("send-reject-email/", SendRejectionEmail.as_view(), name="send_reject_email"),
+        path('applications/user/', UserApplicationsView.as_view(), name='user-applications'),
     ])),
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -7,7 +7,7 @@ from pages.views.post_views import *
 from pages.views.blocked_views import BlockUserView, BlockedListView
 from pages.views.dropdown_views import get_instruments, get_genres
 from pages.views.listing_views import CreateJobListingView, GetJobListingsView, GetAllJobListingsView, GetJobListingView, GetUserFromBusinessView
-from pages.views.application_views import CreateApplicationView, ApplicationsForListingView, AutofillResumeView, GetApplication, SubmitExperiencesView, PatchApplication
+from pages.views.application_views import CreateApplicationView, ApplicationsForListingView, AutofillResumeView, GetApplication, SubmitExperiencesView, PatchApplication, SendAcceptanceEmail
 from django.http import JsonResponse
 
 # For debugging:
@@ -59,5 +59,6 @@ urlpatterns = [
         path("parse-resume/", AutofillResumeView.as_view(), name='parse-resume'),
         path('job-application/<uuid:app_id>/submit-experiences/', SubmitExperiencesView.as_view(), name='submit-experiences'),
         path('user-from-business/<uuid:business_id>/', GetUserFromBusinessView.as_view(), name="user-from-business"),
+        path("send-acceptance-email/", SendAcceptanceEmail.as_view(), name="send_acceptance_email"),
     ])),
 ]

--- a/frontend/src/app/[username]/applications/page.tsx
+++ b/frontend/src/app/[username]/applications/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useRequireAuth } from "@/context/ProfileContext";
+import axios from "axios";
+import Cookies from "js-cookie";
+import styles from "@/styles/Application.module.css";
+
+type Experience = {
+    job_title: string;
+    company_name: string;
+    start_date: string;
+    end_date: string;
+    description: string;
+};
+
+type Application = {
+    id: string;
+    listing: {id: string, event_title: string};
+    first_name: string;
+    last_name: string;
+    phone: string;
+    alt_email: string | null;
+    file_urls: string[];
+    status: string;
+    experiences: Experience[];
+};
+
+export default function MyApplications() {
+    useRequireAuth();
+    const router = useRouter();
+
+    const [applications, setApplications] = useState<Application[]>([]);
+    const [hasMore, setHasMore] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [page, setPage] = useState(1);
+
+    const fetchApplications = async (pageNum = 1) => {
+        try {
+        const token = Cookies.get("access_token");
+        const response = await axios.get(`${process.env.NEXT_PUBLIC_BACKEND_API}/api/applications/user/`, {
+            headers: { Authorization: `Bearer ${token}` },
+            params: { page: pageNum },
+        });
+
+        if (pageNum === 1) {
+            setApplications(response.data.results);
+        } else {
+            setApplications((prev) => [...prev, ...response.data.results]);
+        }
+
+        setHasMore(response.data.next !== null);
+        } catch (err) {
+        console.error("Failed to fetch user applications", err);
+        setHasMore(false);
+        } finally {
+        setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchApplications(1);
+    }, []);
+
+    const loadMoreApps = () => {
+        if (hasMore && !loading) {
+        fetchApplications(page + 1);
+        setPage((prev) => prev + 1);
+        }
+    };
+
+    return (
+        <div className={styles.applicationsContainer}>
+        <button onClick={() => router.back()} className={styles.backButton}>
+            ← Back
+        </button>
+        <h1 className={styles.applicationsTitle}>My Applications</h1>
+        <div className="grid gap-4">
+            {applications.map((app) => (
+            <div key={app.id} className={styles.applicationCard}>
+                <div className={styles.header}>
+                <h2 className={styles.jobTitle}>{app.listing.event_title}</h2>
+                <p className={styles.venue}><strong>Status:</strong> {app.status}</p>
+                <p className={styles.venue}><strong>Submitted as:</strong> {app.first_name} {app.last_name}</p>
+                <p className={styles.venue}><strong>Phone:</strong> {app.phone}</p>
+                <p className={styles.venue}><strong>Alt Email:</strong> {app.alt_email || "N/A"}</p>
+                {app.status === "In-Progress" && (
+                <button
+                    className={styles.finishButton}
+                    onClick={() => router.push(`/application/${app.listing.id}/${app.id}`)}
+                >
+                    Finish Application
+                </button>
+                )}
+
+                {app.experiences?.length > 0 && (
+                    <div className={styles.experienceSection}>
+                    <h3 className={styles.jobTitle}>Experience</h3>
+                    {app.experiences.map((exp, i) => (
+                        <div key={i} className={styles.expCard}>
+                        <p className={styles.venue}><strong>{exp.job_title}</strong> at {exp.company_name}</p>
+                        <p className={styles.venue}>{exp.start_date} – {exp.end_date}</p>
+                        <p className={styles.venue}>{exp.description}</p>
+                        </div>
+                    ))}
+                    </div>
+                )}
+                </div>
+            </div>
+            ))}
+            {hasMore && (
+            <button onClick={loadMoreApps} disabled={loading}>
+                Load More
+            </button>
+            )}
+        </div>
+        </div>
+    );
+}

--- a/frontend/src/app/listing/[id]/page.tsx
+++ b/frontend/src/app/listing/[id]/page.tsx
@@ -73,6 +73,26 @@ export default function ViewApplications() {
         }
     };
 
+    const handleAccept = async (appId: string, applicantEmail: string) => {
+        await updateApplicationStatus(appId, "Accepted");
+    
+        try {
+            const token = Cookies.get("access_token");
+            await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_API}/api/send-acceptance-email/`,
+                { 
+                    application_id: appId,
+                    app_email: applicantEmail,
+                 },
+                { headers: { Authorization: `Bearer ${token}` } }
+            );
+            console.log("Acceptance email sent.");
+
+            updateApplicationStatus(appId, "Accepted")
+        } catch (err) {
+            console.error("Failed to send acceptance email", err);
+        }
+    };
+
     const updateApplicationStatus = async (appId: string, status: string) => {
         try {
             const token = Cookies.get("access_token");
@@ -147,7 +167,7 @@ export default function ViewApplications() {
                         <div className={styles.actionButtons}>
                             <button
                                 className={styles.acceptButton}
-                                onClick={() => updateApplicationStatus(app.id, "Accepted")}
+                                onClick={() => handleAccept(app.id, app.alt_email || app.applicant.email)}
                             >
                             Accept
                             </button>

--- a/frontend/src/app/listing/[id]/page.tsx
+++ b/frontend/src/app/listing/[id]/page.tsx
@@ -74,7 +74,6 @@ export default function ViewApplications() {
     };
 
     const handleAccept = async (appId: string, applicantEmail: string) => {
-        await updateApplicationStatus(appId, "Accepted");
     
         try {
             const token = Cookies.get("access_token");
@@ -90,6 +89,25 @@ export default function ViewApplications() {
             updateApplicationStatus(appId, "Accepted")
         } catch (err) {
             console.error("Failed to send acceptance email", err);
+        }
+    };
+
+    const handleReject = async (appId: string, applicantEmail: string) => {
+    
+        try {
+            const token = Cookies.get("access_token");
+            await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_API}/api/send-reject-email/`,
+                { 
+                    application_id: appId,
+                    app_email: applicantEmail,
+                 },
+                { headers: { Authorization: `Bearer ${token}` } }
+            );
+            console.log("Rejection email sent.");
+
+            updateApplicationStatus(appId, "Rejected")
+        } catch (err) {
+            console.error("Failed to send rejection email", err);
         }
     };
 
@@ -173,7 +191,7 @@ export default function ViewApplications() {
                             </button>
                             <button
                                 className={styles.rejectButton}
-                                onClick={() => updateApplicationStatus(app.id, "Rejected")}
+                                onClick={() => handleReject(app.id, app.alt_email || app.applicant.email)}
                             >
                             Reject
                             </button>

--- a/frontend/src/app/listing/[id]/page.tsx
+++ b/frontend/src/app/listing/[id]/page.tsx
@@ -25,7 +25,7 @@ type Application = {
   last_name: string;
   phone: string;
   alt_email: string | null;
-  file_keys: string[];
+  file_urls: string[];
   status: string;
   experiences: Experience[];
 };
@@ -54,9 +54,9 @@ export default function ViewApplications() {
             });
 
             if (pageNum === 1) {
-                setApplications(response.data);
+                setApplications(response.data.results);
             } else {
-                setApplications((prevApps) => [...prevApps, ...response.data]);
+                setApplications((prevApps) => [...prevApps, ...response.data.results]);
             }
 
             setHasMore(response.data.next !== null);
@@ -132,9 +132,9 @@ export default function ViewApplications() {
                         )}
                     </div>
                         <div className={styles.applicationActions}>
-                        {app.file_keys.length > 0 ? (
+                        {app.file_urls.length > 0 ? (
                             <a
-                            href={`https://your-s3-bucket.s3.amazonaws.com/${app.file_keys[0]}`}
+                            href={`${app.file_urls[0]}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.resumeButton}

--- a/frontend/src/app/listing/[id]/page.tsx
+++ b/frontend/src/app/listing/[id]/page.tsx
@@ -145,9 +145,15 @@ export default function ViewApplications() {
 
     return (
         <div className={styles.applicationsContainer}>
+            <button
+                onClick={() => router.back()}
+                className={styles.backButton}
+            >
+                ← Back
+            </button>
             <h1 className={styles.applicationsTitle}>Applications for Job #{id}</h1>
             <div className="grid gap-4">
-                {applications.map((app) => (
+                {applications.filter((app) => app.status !== "In-Progress").map((app) => (
                     <div key={app.id} className={styles.applicationCard}>
                     <div className={styles.header}>
                         <h2 className={styles.jobTitle}>{app.first_name} {app.last_name}</h2>

--- a/frontend/src/components/toolbars/toolbar.tsx
+++ b/frontend/src/components/toolbars/toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Box, Avatar } from "@mui/material";
-import { Home, Search, Add, Chat, Settings } from "@mui/icons-material";
+import { Home, Search, Add, Chat, Settings, Assignment } from "@mui/icons-material";
 import { useRouter } from "next/navigation";
 import { Sun, Moon } from "lucide-react";
 import { useTheme } from "@/context/ThemeContext";
@@ -44,11 +44,15 @@ const Toolbar = () => {
                 router.push(`/${profile?.username}/business`)
     }
 
+    const handleAppClick = () => {
+        router.push(`/${profile?.username}/applications`)
+    }
+
     return (
         <Box
         sx={{
             position: 'fixed',
-            width: '10%',
+            width: '12%',
             height: '100%',
             display: 'flex',
             flexDirection: 'column',
@@ -64,6 +68,11 @@ const Toolbar = () => {
             <Button variant="contained" startIcon={<Home />} onClick={handleFeedClick}>Feed</Button>
             <Button variant="contained" startIcon={<Search />} onClick={handleDiscoverClick}>Discover</Button>
             <Button variant="contained" startIcon={<Add />} onClick={handleJobsClick}>Jobs</Button>
+            {profile?.role === "musician" && (
+                <Button variant="contained" startIcon={<Assignment />} onClick={handleAppClick}>
+                    My Application
+                </Button>
+            )}
             <Button variant="contained" startIcon={<Chat />} onClick={handleMessagesClick}>Messages</Button>
             <Button variant="contained" startIcon={<Settings />} onClick={handleSettingsClick}>Settings</Button>
             <Button variant="contained" onClick={handleAdminClick}>Admin</Button>

--- a/frontend/src/styles/Application.module.css
+++ b/frontend/src/styles/Application.module.css
@@ -317,6 +317,42 @@
     background-color: #dc2626;
 }  
 
+.backButton {
+    margin-bottom: 1rem;
+    padding: 0.5rem 1rem;
+    background-color: transparent;
+    color: #2563eb;
+    border: none;
+    font-size: 1.15rem;
+    font-weight: bold;
+    cursor: pointer;
+    text-decoration: underline;
+    display: inline-block;
+    transition: color 0.2s ease;
+}
+
+.backButton:hover {
+    color: #1d4ed8;
+}
+
+.finishButton {
+    background-color: #0070f3;
+    color: white;
+    border: none;
+    font-size: 1.15rem;
+    font-weight: bold;
+    padding: 0.5rem 1rem;
+    margin-top: 1rem;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+.finishButton:hover {
+    background-color: #005bb5;
+}
+  
+
 [data-theme="dark"] .input[type="date"]::-webkit-calendar-picker-indicator {
     filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(180deg);
   }


### PR DESCRIPTION
- [x] Code within request follows correct coding standards as established by the team
- [ ] Code within request has tests written and passing (if relevant)
- [x] I have pulled the Sprint# branch down to my current branch and all prior functionality persists

## Summary
This PR allows a business to Accept and Reject applications. Upon doing one of these two functions, the musician will receive an email accordingly. Business's also have the ability to view the musicians resume. 

The other feature in this PR is the ability for a musician to view their applications and their statuses under the "My Application" toolbar tab. If an application was unfinished, they will have the opportunity to finish the application from this page.
 
## Added Tests
backend/test/views/application/ApplicationViewTest.py

## Dependencies
NA

## QA Suggestions
Create a job application for a job, ensuring the alt_email is a personal email you can access. Once complete, navigate to the business's profile and click "View Applicants" on this page. Once on this page, click accept. You should receive an acceptance email. Click reject, you should then receive the rejection email. Click View Resume, you should be able to view the resume. 

Now login as a musician and click "My Applications" in the toolbar. You should see the application you just filled out there, with the status "Rejected". Now create another application, but once you reach the experience page, navigate back to the "My Applications" page. You should see the beginning of the application with the status "In-Progress" and a button allowing you to finish the application. Clicking this button will take you to the experience page to finish the application. In-Progress status applications will not show up on the business page "View Applicant" page.